### PR TITLE
add support for passing in an offerConfigUUID

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,14 @@ jobs:
           set -o pipefail
           ./gradlew :sdk:testReleaseUnitTest | grep -v "sensitive"
 
+      - name: Print Test Failures
+        if: failure()
+        run: |
+          echo "::group::Test Failures"
+          find sdk/build/reports/tests -name "*.html" -exec echo "Report: {}" \;
+          find sdk/build/test-results -name "*.xml" -print0 | xargs -0 -I {} sh -c 'echo "--- {} ---" && grep -A 5 "failure\|error" "{}" || true'
+          echo "::endgroup::"
+
       # Run Android Lint
       - name: Run Android Lint
         run: |

--- a/sdk/src/main/java/co/imprint/sdk/domain/model/ImprintConfiguration.kt
+++ b/sdk/src/main/java/co/imprint/sdk/domain/model/ImprintConfiguration.kt
@@ -15,10 +15,15 @@ import kotlinx.parcelize.Parcelize
 data class ImprintConfiguration(
   val clientSecret: String,
   val environment: ImprintEnvironment = ImprintEnvironment.PRODUCTION,
+  val offerConfigUUID: String? = null,
   internal val customHostUrl: String? = null,
 ) : Parcelable {
 
   @IgnoredOnParcel
-  internal val webUrl: String =
-    "${customHostUrl ?: environment.hostUrl}/start?client_secret=${clientSecret}"
+  internal val webUrl: String = buildString {
+    append("${customHostUrl ?: environment.hostUrl}/start?client_secret=${clientSecret}")
+    if (offerConfigUUID != null) {
+      append("&offerConfigUUIDs=${offerConfigUUID}")
+    }
+  }
 }

--- a/sdk/src/test/java/co/imprint/sdk/domain/model/ImprintConfigurationTest.kt
+++ b/sdk/src/test/java/co/imprint/sdk/domain/model/ImprintConfigurationTest.kt
@@ -46,7 +46,7 @@ class ImprintConfigurationTest {
 
     assertTrue(config.webUrl.startsWith("https://apply.sbx.imprint.co/start?"))
     assertTrue(config.webUrl.contains("client_secret=sbx-secret"))
-    assertTrue(config.webUrl.contains("offerConfigUUID=sbx-offer-uuid"))
+    assertTrue(config.webUrl.contains("offerConfigUUIDs=sbx-offer-uuid"))
   }
 
   @Test

--- a/sdk/src/test/java/co/imprint/sdk/domain/model/ImprintConfigurationTest.kt
+++ b/sdk/src/test/java/co/imprint/sdk/domain/model/ImprintConfigurationTest.kt
@@ -1,0 +1,71 @@
+package co.imprint.sdk.domain.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+class ImprintConfigurationTest {
+
+  @Test
+  fun `webUrl does not contain offerConfigUUID when null`() {
+    val config = ImprintConfiguration(
+      clientSecret = "test-secret",
+      environment = ImprintEnvironment.PRODUCTION,
+    )
+
+    assertEquals(
+      "https://apply.imprint.co/start?client_secret=test-secret",
+      config.webUrl,
+    )
+    assertFalse(config.webUrl.contains("offerConfigUUIDs"))
+  }
+
+  @Test
+  fun `webUrl contains offerConfigUUID when provided`() {
+    val config = ImprintConfiguration(
+      clientSecret = "test-secret",
+      environment = ImprintEnvironment.PRODUCTION,
+      offerConfigUUID = "offer-uuid-123",
+    )
+
+    assertEquals(
+      "https://apply.imprint.co/start?client_secret=test-secret&offerConfigUUIDs=offer-uuid-123",
+      config.webUrl,
+    )
+  }
+
+  @Test
+  fun `webUrl with sandbox environment and offerConfigUUID`() {
+    val config = ImprintConfiguration(
+      clientSecret = "sbx-secret",
+      environment = ImprintEnvironment.SANDBOX,
+      offerConfigUUID = "sbx-offer-uuid",
+    )
+
+    assertTrue(config.webUrl.startsWith("https://apply.sbx.imprint.co/start?"))
+    assertTrue(config.webUrl.contains("client_secret=sbx-secret"))
+    assertTrue(config.webUrl.contains("offerConfigUUID=sbx-offer-uuid"))
+  }
+
+  @Test
+  fun `offerConfigUUID defaults to null`() {
+    val config = ImprintConfiguration(clientSecret = "secret")
+    assertNull(config.offerConfigUUID)
+  }
+
+  @Test
+  fun `webUrl with custom host and offerConfigUUID`() {
+    val config = ImprintConfiguration(
+      clientSecret = "test-secret",
+      offerConfigUUID = "custom-offer-uuid",
+      customHostUrl = "https://custom.example.com",
+    )
+
+    assertEquals(
+      "https://custom.example.com/start?client_secret=test-secret&offerConfigUUIDs=custom-offer-uuid",
+      config.webUrl,
+    )
+  }
+}


### PR DESCRIPTION
See https://imprint.atlassian.net/browse/SPND-3805

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `offerConfigUUID` parameter support to `ImprintConfiguration`
> Adds an optional `offerConfigUUID` property to the [`ImprintConfiguration`](https://github.com/Imprint-Tech/imprint-sdk-android/pull/28/files#diff-b0c9ea60270555fd25f8bbb0928dbdf8b09e02c2e7c29123631e90b052c8f057) data class. When non-null, the value is appended as an `offerConfigUUIDs` query parameter to `webUrl`. Five unit tests cover null/non-null behavior across sandbox, production, and custom host URL configurations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3840b54.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->